### PR TITLE
fix: Use Time whereever possible, avoid DateTime and Date.

### DIFF
--- a/app/controllers/sepa_export_controller.rb
+++ b/app/controllers/sepa_export_controller.rb
@@ -12,7 +12,7 @@ class SepaExportController < ApplicationController
 			if params[:year]
 				@year = params[:year].to_i
 			else
-				@year = Date.today.year
+				@year = Date.current.year
 			end
 			breadcrumb Person.model_name.human(count: :other), :people_path
 			breadcrumb "SEPA-Export Mitgliedschaft #{@year}", sepa_export_path(year: @year)
@@ -35,7 +35,7 @@ class SepaExportController < ApplicationController
 
 		to_use = params[:transactions].values.select {|transaction| transaction[:use] == "1"}
 		add_persons to_use
-		execution_date = Date.parse(params[:execution_date])
+		execution_date = Time.zone.parse(params[:execution_date])
 
 		begin
 			sepa_direct_debit = create_direct_debit to_use, execution_date

--- a/app/helpers/banking_statement_import_helper.rb
+++ b/app/helpers/banking_statement_import_helper.rb
@@ -112,7 +112,7 @@ module BankingStatementImportHelper
 		{
 			**payment_data,
 			amount: Float(line['Betrag'].gsub(/,/, '.')),
-			payment_date: DateTime.strptime(line['Buchungstag'], '%d.%m.%y')
+			payment_date: Time.strptime(line['Buchungstag'], '%d.%m.%y')
 		}
 	end
 
@@ -123,7 +123,7 @@ module BankingStatementImportHelper
 			unless Rails.configuration.membership_fee == amount
 				raise "Mitgliedsbeitrag ist #{Rails.configuration.membership_fee} nicht #{amount}."
 			end
-			if person.paid_until >= DateTime.new(payment[:year]).end_of_year.yesterday
+			if person.paid_until.to_time.end_of_day >= Time.new(payment[:year]).end_of_year
 				raise "Person #{person.full_name} hat schon für das Jahr #{payment[:year]} gezahlt."
 			end
 		elsif payment[:type] == :sponsor_membership
@@ -148,7 +148,7 @@ module BankingStatementImportHelper
 
 	def apply_payment(payment)
 		if payment[:type] == :membership
-			year_date = DateTime.new(payment[:year])
+			year_date = Time.new(payment[:year])
 			Payment.create(
 				person: payment[:person],
 				payment_type: :regular_member,

--- a/app/helpers/sepa_export_helper.rb
+++ b/app/helpers/sepa_export_helper.rb
@@ -6,7 +6,7 @@ module SepaExportHelper
 	end
 
 	def get_transactions_for_members(year)
-		cutoff_date = DateTime.new(year).beginning_of_year
+		cutoff_date = Time.new(year).beginning_of_year
 		Person
 			.where(paid_until: ..cutoff_date)
 			.where(member_until: cutoff_date..)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -123,7 +123,7 @@ class Event < ApplicationRecord
 
 	# Ist der Anmeldeschluss schon vorbei
 	def deadline_missed?
-		return !deadline.nil? && Date.today > deadline
+		return !deadline.nil? && Date.current > deadline
 	end
 
 	# Ist die Veranstaltung derzeit noch von Organisatoren bearbeitbar

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -69,13 +69,13 @@ class Person < ApplicationRecord
 
 	# Berechne das Ende des bezahlten Zeitraums
 	def paid_until_function
-		now = Time.now
+		now = Time.current
 		maximal_gap = 1.week # Vermeidet Lücken vom 31.12 -> 1.1
 
 		# TODO Fördermitgliedschaft
 		intervals = payments.where(payment_type: [:regular_member, :free_member, :sponsor_and_member]).pluck(:start, :end)
 		times = intervals.map{|s, e|
-			[[s - maximal_gap, 1], [e, -1]]}.flatten(1).sort
+			[[s.to_time - maximal_gap, 1], [e.to_time, -1]]}.flatten(1).sort
 
 		# Die Mitgliedschaft ist bis zum Ende des Beitrittsjahres kostenlos
 		if intervals.empty?
@@ -138,11 +138,11 @@ class Person < ApplicationRecord
 	# ********************
 
 	def member?
-		member_at_time?(Time.now)
+		member_at_time?(Time.current)
 	end
 
 	def member_at_time?(time)
-		!joined.nil? && joined <= time &&
+		!joined.nil? && joined.to_time <= time &&
 		!member_until.nil? && member_until > time
 	end
 

--- a/app/views/sepa_export/verify.erb
+++ b/app/views/sepa_export/verify.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="aligned">
         <%= form.label :execution_date, t('actions.export_sepa.execution_date') %>
-        <%= form.date_field :execution_date, {:required => true, value: Date.today + 14} %>
+        <%= form.date_field :execution_date, {:required => true, value: Date.current + 14} %>
       </div>
 
       <div class="actions">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ Person.transaction do
 		first_name:       "Adminis",
 		last_name:        "Trator",
 		account_name:     "Admin",
-		birthday:         Time.now,
+		birthday:         Time.current,
 		email_address:    "adminsistrator@email.de",
 		active:           true,
 		gender:           :male,

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,41 +1,41 @@
 require 'test_helper'
 
-class GroupTest < ActiveSupport::TestCase	
+class GroupTest < ActiveSupport::TestCase
 	test "all subgroups" do
-		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so).sort, 
+		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so).sort,
 			groups(:group_gl).subgroups.to_a.sort
-		assert_equal groups(:group_o, :group_so).sort, 
+		assert_equal groups(:group_o, :group_so).sort,
 			groups(:group_o).subgroups.to_a.sort
-		assert_equal groups(:group_sl, :group_so).sort, 
+		assert_equal groups(:group_sl, :group_so).sort,
 			groups(:group_sl).subgroups.to_a.sort
 		assert_equal [groups(:group_so)],
-			groups(:group_so).subgroups.to_a		
-		assert_equal groups(:group_q, :group_z).sort, 
+			groups(:group_so).subgroups.to_a
+		assert_equal groups(:group_q, :group_z).sort,
 			groups(:group_q).subgroups.to_a.sort
 	end
-	
-	test "all supergroups" do		
-		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so).sort, 
+
+	test "all supergroups" do
+		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so).sort,
 			groups(:group_so).supergroups.sort
 	end
-	
-	test "timed affiliations" do	
+
+	test "timed affiliations" do
 		Affiliation.create!({
 			group: groups(:group_so),
 			groupable: groups(:group_q),
-			start: Time.now - 2.year,
-			end: Time.now - 1.year,
+			start: Time.current - 2.year,
+			end: Time.current - 1.year,
 			groupable_type: 'Group'})
-		assert_equal groups(:group_sl, :group_so).sort, 
+		assert_equal groups(:group_sl, :group_so).sort,
 			groups(:group_sl).subgroups.to_a.sort
-			
+
 		Affiliation.create!({
 			group: groups(:group_so),
 			groupable: groups(:group_z),
-			start: Time.now - 2.year,
-			end: Time.now + 3.year,
+			start: Time.current - 2.year,
+			end: Time.current + 3.year,
 			groupable_type: 'Group'})
-		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so, :group_z).sort, 
+		assert_equal groups(:group_gl, :group_sl, :group_o, :group_so, :group_z).sort,
 			groups(:group_gl).subgroups.to_a.sort
 	end
 end


### PR DESCRIPTION
Time is datezone aware, where Date is not and DateTime is not by default. One should also avoid .now and use .current, to get now in the correct time zone.

Resources:
http://danilenko.org/2012/7/6/rails_timezones/ (A bit outdated since it doesn't have Time.current and Time.strptime works without explicit time zone in the mean time)