### PR TITLE
feat: privileged users can enable/disable privileges

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,17 @@
+class AdminController < ApplicationController
+    include PolicyHelper
+
+    breadcrumb 'admin', :admin_path
+
+    def enable_privileged_mode
+        session[:mode] = 'privileged'
+        flash[:notice] = t('actions.admin.enter_privileged_mode')
+        redirect_to root_path
+    end
+
+    def disable_privileged_mode
+        session[:mode] = 'standard'
+        flash[:notice] = t('actions.admin.exit_privileged_mode')
+        redirect_to root_path
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,13 @@
+# UserContext um den privilegierten Modus an die Pundit policies durchzureichen
+class UserContext
+  attr_reader :user, :mode
+
+  def initialize(user, mode)
+    @user = user
+    @mode = mode == 'privileged' ? 'privileged' : 'standard'
+  end
+end
+
 class ApplicationController < ActionController::Base
   include Pundit
 
@@ -19,6 +29,10 @@ class ApplicationController < ActionController::Base
       type.all { render nothing: true, status: :forbidden }
     end
     true
+  end
+
+  def pundit_user
+    UserContext.new(current_user, session[:mode])
   end
 
   def user_for_paper_trail

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,4 +70,19 @@ module ApplicationHelper
   def admin_email_link
     mail_to Rails.configuration.admin_email_address
   end
+
+  def privileged_mode_link
+    return unless toggle_privileged_mode?
+
+    if session[:mode] == 'privileged'
+      icon_button t('actions.admin.exit_privileged_mode'), 'lock_open', send("admin_standard_mode_path")
+    else
+      icon_button t('actions.admin.enter_privileged_mode'), 'lock', send("admin_privileged_mode_path")
+    end
+  end
+
+  # kann user in den priviliegierten Modus wechseln?
+  def toggle_privileged_mode?
+    current_user.admin? || current_user.chairman? || current_user.treasurer?
+  end
 end

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -1,0 +1,16 @@
+module PolicyHelper
+  # ist user ein Admin und im priviliegierten Modus?
+  def active_admin?(user, mode)
+    user&.admin? && mode == 'privileged'
+  end
+
+  # ist user ein Chairman und im priviliegierten Modus?
+  def active_chairman?(user, mode)
+    user&.chairman? && mode == 'privileged'
+  end
+
+  # ist user ein Treasurer und im priviliegierten Modus?
+  def active_treasurer?(user, mode)
+    user&.treasurer? && mode == 'privileged'
+  end
+end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,8 +1,9 @@
 # Das allgemiene Berechtigungskonzept für verschiedene Adminbereichte
 # Wird zum Konfigurieren von Gruppen, Emailverteiler und Versionsständen hergenommen
 
-class AdminPolicy
+class AdminPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications({
                         viewable: %i[show index],
@@ -11,8 +12,9 @@ class AdminPolicy
   alias update? edit?
   alias create? new?
 
-  def initialize(user, _object)
-    return unless user.admin? || user.chairman?
+  def initialize(user_context, _object)
+    super
+    return unless active_admin?(@user, @mode) || active_chairman?(@user, @mode)
 
     grant :editable
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,9 @@
+class ApplicationPolicy
+  attr_reader :user_context, :record
+
+  def initialize(user_context, record)
+    @user = user_context.user
+    @mode = user_context.mode
+    @record = record
+  end
+end

--- a/app/policies/banking_policy.rb
+++ b/app/policies/banking_policy.rb
@@ -1,5 +1,6 @@
-class BankingPolicy
+class BankingPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications(
     {
@@ -7,8 +8,9 @@ class BankingPolicy
     }
   )
 
-  def initialize(user, _unused)
-    return unless user.treasurer?
+  def initialize(user_context, _unused)
+    super
+    return unless active_treasurer?(@user, @mode)
 
     grant :by_treasurer
   end

--- a/app/policies/database_policy.rb
+++ b/app/policies/database_policy.rb
@@ -1,5 +1,6 @@
 DatabasePolicy = Struct.new(:user, :database) do
   include PunditImplications
+  include PolicyHelper
 
   define_implications(
     {
@@ -7,8 +8,9 @@ DatabasePolicy = Struct.new(:user, :database) do
     }
   )
 
-  def initialize(user, _object)
-    return unless user.admin? || user.chairman?
+  def initialize(user_context, _object)
+    super
+    return unless active_admin?(@user, @mode) || active_chairman?(@user, @mode)
 
     grant :by_admin
   end

--- a/app/policies/finance_review_policy.rb
+++ b/app/policies/finance_review_policy.rb
@@ -1,5 +1,6 @@
-class FinanceReviewPolicy
+class FinanceReviewPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications(
     {
@@ -8,8 +9,9 @@ class FinanceReviewPolicy
     }
   )
 
-  def initialize(user, _)
-    grant :by_treasurer if user.treasurer?
-    grant :by_auditor if user.auditor?
+  def initialize(user_context, _)
+    super
+    grant :by_treasurer if active_treasurer?(@user, @mode)
+    grant :by_auditor if @user.auditor?
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,8 +1,12 @@
 class GroupPolicy < AdminPolicy
+  include PunditImplications
+  include PolicyHelper
+
   # Wie AdminPolicy, aber einige der vordefinierten Gruppen sollen auch
   # von Admins nicht geändert beziehungsweise gelöscht werden dürfen
-  def initialize(user, group)
-    return unless user.admin? || user.chairman?
+  def initialize(user_context, group)
+    super
+    return unless active_admin?(@user, @mode) || active_chairman?(@user, @mode)
 
     if group.is_a?(Group)
       grant :viewable

--- a/app/policies/hostel_policy.rb
+++ b/app/policies/hostel_policy.rb
@@ -1,5 +1,6 @@
-class HostelPolicy
+class HostelPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications({
                         by_member: %i[show index],
@@ -9,10 +10,11 @@ class HostelPolicy
   alias update? edit?
   alias create? new?
 
-  def initialize(user, _hostel)
-    if user.admin? || user.chairman? || user.organizing_now?
+  def initialize(user_context, _hostel)
+    super
+    if active_admin?(@user, @mode) || active_chairman?(@user, @mode) || @user.organizing_now?
       grant :by_admin
-    elsif user.member?
+    elsif @user.member?
       grant :by_member
     end
   end

--- a/app/policies/outstanding_payments_policy.rb
+++ b/app/policies/outstanding_payments_policy.rb
@@ -1,5 +1,6 @@
-class OutstandingPaymentsPolicy
+class OutstandingPaymentsPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications(
     {
@@ -8,8 +9,9 @@ class OutstandingPaymentsPolicy
     }
   )
 
-  def initialize(user, _)
-    grant :by_treasurer if user.treasurer?
-    grant :by_auditor if user.auditor?
+  def initialize(user_context, _)
+    super
+    grant :by_treasurer if active_treasurer?(@user, @mode)
+    grant :by_auditor if @user.auditor?
   end
 end

--- a/app/policies/registration_policy.rb
+++ b/app/policies/registration_policy.rb
@@ -30,8 +30,9 @@
 # by_admin
 #   Das dürfen Administratoren tun
 
-class RegistrationPolicy
+class RegistrationPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications({
                         edit_general: [:view_general],
@@ -51,16 +52,17 @@ class RegistrationPolicy
                       })
 
   # TODO: Rechtesystem für Veranstaltung und Person prüfen
-  def initialize(user, reg)
-    grant :by_admin if user.admin?
-    grant :by_treasurer if user.treasurer?
-    grant :by_auditor if user.auditor?
-    grant :by_chairman if user.chairman?
+  def initialize(user_context, reg)
+    super
+    grant :by_admin if active_admin?(@user, @mode)
+    grant :by_treasurer if active_treasurer?(@user, @mode)
+    grant :by_auditor if @user.auditor?
+    grant :by_chairman if active_chairman?(@user, @mode)
     grant :by_organizer if reg.is_a?(Registration) &&
-                           user.organizer?(reg.event) && reg.event.still_organizable?
-    grant :by_self if reg.is_a?(Registration) && !reg.person.nil? && user.id == reg.person.id
-    grant :by_participant if reg.is_a?(Registration) && user.participant?(reg.event)
-    grant :by_member if user.member?
+                           @user.organizer?(reg.event) && reg.event.still_organizable?
+    grant :by_self if reg.is_a?(Registration) && !reg.person.nil? && @user.id == reg.person.id
+    grant :by_participant if reg.is_a?(Registration) && @user.participant?(reg.event)
+    grant :by_member if @user.member?
     grant :by_other
   end
 

--- a/app/policies/version_policy.rb
+++ b/app/policies/version_policy.rb
@@ -6,18 +6,20 @@ module PaperTrail
   end
 end
 
-class VersionPolicy
+class VersionPolicy < ApplicationPolicy
   include PunditImplications
+  include PolicyHelper
 
   define_implications({
                         by_chairman: %i[index show],
                         by_admin: %i[by_chairman revert_all]
                       })
 
-  def initialize(user, _object)
-    if user.admin?
+  def initialize(user_context, _object)
+    super
+    if active_admin?(@user, @mode)
       grant :by_admin
-    elsif user.chairman?
+    elsif active_chairman?(@user, @mode)
       grant :by_chairman
     end
   end

--- a/app/views/shared/_menu_bar.erb
+++ b/app/views/shared/_menu_bar.erb
@@ -12,6 +12,7 @@
 		<%= banking_statement_import_link %>
 		<%= outstanding_payments_link %>
 		<%= finance_review_link %>
+		<%= privileged_mode_link %>
 	</nav>
 
 	<div class="breadcrumb">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/locales/controller.de.yml
+++ b/config/locales/controller.de.yml
@@ -132,6 +132,9 @@ de:
       edit_privacy: Datenschutz einstellen
       groups: Rechte
       edit_groups: Rechte
+    admin:
+      enter_privileged_mode: Privilegierter Modus
+      exit_privileged_mode: Standardmodus
     event:
       new: Neue Veranstaltung eintragen
       edit: Veranstaltung bearbeiten

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   post '/sepa_export', to: 'sepa_export#export'
 
   get '/admin', to: 'admin#show'
+  get '/admin/privileged_mode', to: 'admin#enable_privileged_mode'
+  get '/admin/standard_mode', to: 'admin#disable_privileged_mode'
 
   get '/outstanding_payments', action: :show, controller: 'outstanding_payments'
   get '/finance_review', action: :show, controller: 'finance_review'


### PR DESCRIPTION
Implementiert https://github.com/qed-verein/qeddb-ruby/issues/29.

Hier war etwas Gebastel vonnöten: Der aktuelle Modus wird in der session gespeichert. Um diese Information an die Policen durchzureichen, wird sie an den `pundit_user` übergeben und dann in der `ApplicationPolicy` wieder extrahiert. DIe anderen Policen werden entsprechend angepasst.

Die Menüleiste wird um einen Button erweitert, mit dem der Modus gewechselt werden kann. Die entsprechenden Funktionen hierfür habe ich in einen `AdminController`  und in `ApplicationHelper` gepackt, bin mir aber etwas unsicher, ob das der richtige Ort dafür ist.
