### PR TITLE
Bugfix: Always enable links for organizer in registration table view

### DIFF
--- a/app/views/events/registrations.erb
+++ b/app/views/events/registrations.erb
@@ -69,7 +69,7 @@
 		<% if r.status != 'dummy' || view_dummy %>
 			<tr class='<%= 'inactive' if !r.active? %>'>
 				<td></td>
-				<% if view_registration %>
+				<% if view_private || view_registration %>
 					<td><%= link_to r.person.first_name, r %></td>
 					<td><%= link_to r.person.last_name, r %></td>
 				<% else %>


### PR DESCRIPTION
Links in der Anmeldungs-Tabellenansicht zu den Anmeldungne sollen für Orgas immer aktiv sein